### PR TITLE
fix(ci): use GH_TOKEN in release workflow to bypass branch protection

### DIFF
--- a/.github/workflows/cron-weekly-release.yaml
+++ b/.github/workflows/cron-weekly-release.yaml
@@ -124,13 +124,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       - name: 👤 Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: 🧹 Close stale release PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           mapfile -t PR_NUMBERS < <(
             gh pr list \
@@ -172,7 +173,7 @@ jobs:
           NEW_VERSION=$(npm version "$BUMP_TYPE" --no-git-tag-version)
           echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-      - name: 💾 Commit and tag
+      - name: 💾 Commit, tag, and push
         run: |
           git add package.json package-lock.json
           git commit -m "chore(release): ${{ steps.bump.outputs.version }}"
@@ -180,6 +181,8 @@ jobs:
           git push origin main --tags
       - name: 📦 Create GitHub Release
         uses: softprops/action-gh-release@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.bump.outputs.version }}
           name: ${{ steps.bump.outputs.version }}


### PR DESCRIPTION
## Summary

- Use `GH_TOKEN` (PAT) instead of `GITHUB_TOKEN` for checkout + push in the release workflow
- `GITHUB_TOKEN` cannot bypass branch protection rules (require PRs, signed commits), which caused the release to fail with `GH013: Repository rule violations`
- Also use `GH_TOKEN` for the GitHub Release creation and stale PR cleanup

This is the root cause of why no release was created after v5.1.0.

## Test plan

- [ ] Trigger the release workflow manually after merge
- [ ] Verify v5.2.0 release is created successfully

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>