### PR TITLE
fix(ci): rework release workflow to work with branch protection

### DIFF
--- a/.github/workflows/cron-weekly-release.yaml
+++ b/.github/workflows/cron-weekly-release.yaml
@@ -124,7 +124,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       - name: 👤 Configure git
         run: |
           git config user.name "github-actions[bot]"
@@ -138,11 +137,11 @@ jobs:
               --state open \
               --base main \
               --json number,headRefName \
-              --jq '.[] | select(.headRefName | startswith("release-please--")) | .number'
+              --jq '.[] | select(.headRefName | startswith("release-please--") or startswith("release/")) | .number'
           )
 
           if [[ ${#PR_NUMBERS[@]} -eq 0 ]]; then
-            echo "No stale release-please PRs found."
+            echo "No stale release PRs found."
             exit 0
           fi
 
@@ -150,7 +149,7 @@ jobs:
             echo "Closing stale release PR #$pr"
             gh pr close "$pr" --comment "Closed by weekly automated release workflow."
           done
-      - name: 🔢 Bump version
+      - name: 🔢 Determine version
         id: bump
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -173,41 +172,51 @@ jobs:
           NEW_VERSION=$(npm version "$BUMP_TYPE" --no-git-tag-version)
           echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-      - name: 💾 Commit, tag, and push
+      - name: 📦 Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
+          gh release create "${{ steps.bump.outputs.version }}" \
+            --target main \
+            --title "${{ steps.bump.outputs.version }}" \
+            --notes "$(cat <<RELEASE_EOF
+          ## 📦 Weekly Plugin Release — ${{ steps.bump.outputs.version }}
+
+          ${{ needs.check-updates.outputs.changelog }}
+
+          ---
+
+          ### 🔗 Usage
+
+          Update your \`.trunk/trunk.yaml\` to use this version:
+
+          \`\`\`yaml
+          plugins:
+            sources:
+              - id: navigaite
+                uri: https://github.com/navigaite/nvgt-trunk-plugin
+                ref: ${{ steps.bump.outputs.version }}
+          \`\`\`
+
+          ---
+          _Automated weekly release by Navigaite CI/CD_
+          RELEASE_EOF
+          )"
+      - name: 🔄 Create version bump PR
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="release/${{ steps.bump.outputs.version }}"
+          git checkout -b "$BRANCH"
           git add package.json package-lock.json
           git commit -m "chore(release): ${{ steps.bump.outputs.version }}"
-          git tag "${{ steps.bump.outputs.version }}"
-          git push origin main --tags
-      - name: 📦 Create GitHub Release
-        uses: softprops/action-gh-release@v2.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.bump.outputs.version }}
-          name: ${{ steps.bump.outputs.version }}
-          body: |
-            ## 📦 Weekly Plugin Release — ${{ steps.bump.outputs.version }}
-
-            ${{ needs.check-updates.outputs.changelog }}
-
-            ---
-
-            ### 🔗 Usage
-
-            Update your `.trunk/trunk.yaml` to use this version:
-
-            ```yaml
-            plugins:
-              sources:
-                - id: navigaite
-                  uri: https://github.com/navigaite/nvgt-trunk-plugin
-                  ref: ${{ steps.bump.outputs.version }}
-            ```
-
-            ---
-            _Automated weekly release by Navigaite CI/CD_
-          generate_release_notes: false
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore(release): ${{ steps.bump.outputs.version }}" \
+            --body "Automated version bump to ${{ steps.bump.outputs.version }}." \
+            --base main \
+            --head "$BRANCH" \
+            --label "automerge"
       - name: 📊 Release Summary
         run: |
           echo "### 📦 Release Created" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Reworked release workflow to work with strict branch protection rulesets
- Instead of pushing directly to main (blocked by "require PRs" + "signed commits" rules), the workflow now:
  1. Creates the tag + GitHub Release via `gh release create` (no push needed)
  2. Opens a PR for the version bump with `automerge` label (goes through CI)
- Also cleans up stale `release/` branches in addition to `release-please--` branches

The previous approach failed with `GH013: Repository rule violations` because neither `GITHUB_TOKEN` nor `GH_TOKEN` have bypass permissions for the branch protection rulesets.

## Test plan

- [ ] Merge this PR, then trigger the release workflow manually
- [ ] Verify the tag, GitHub Release, and version bump PR are created

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>