### PR TITLE
feat(ci): add Claude Code action for Copilot review auto-reply

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@
 # Navigaite Universal CI/CD Pipeline
 # Uses shared reusable workflow from navigaite/.github
 
-name: CI/CD Pipeline
+name: Navigaite CI/CD Pipeline
 
 on:
   push:

--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -27,15 +27,18 @@ jobs:
   claude:
     # Skip unnecessary runner spin-ups:
     # - review submitted: only for Copilot bot
-    # - review comments: only for @claude mentions
-    # - issue comments: only for @claude mentions
+    # - review/issue comments: only @claude mentions from trusted authors
     if: >-
       (github.event_name == 'pull_request_review' &&
         github.event.review.user.login == 'copilot[bot]') ||
       (github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude')) ||
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'),
+        github.event.comment.author_association)) ||
       (github.event_name == 'issue_comment' &&
-        contains(github.event.comment.body, '@claude'))
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["MEMBER","OWNER","COLLABORATOR"]'),
+        github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -1,0 +1,51 @@
+---
+name: Claude Code
+
+on:
+  # Fix Copilot review comments once its review is submitted
+  pull_request_review:
+    types: [submitted]
+
+  # Fix individual review comments when @claude is mentioned
+  pull_request_review_comment:
+    types: [created]
+
+  # Handle @claude mentions in PR / issue discussions
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: claude-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude:
+    # Skip unnecessary runner spin-ups:
+    # - review submitted: only for Copilot bot
+    # - review comments: only for @claude mentions
+    # - issue comments: only for @claude mentions
+    if: >-
+      (github.event_name == 'pull_request_review' &&
+        github.event.review.user.login == 'copilot[bot]') ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Let Copilot review comments trigger Claude fixes
+          allowed_bots: copilot[bot]


### PR DESCRIPTION
## Summary
- Add Claude Code GitHub Action workflow that auto-replies to Copilot review comments
- Triggers on: Copilot review submissions, `@claude` mentions in review comments, `@claude` mentions in issue/PR discussions
- Uses org-level `CLAUDE_CODE_OAUTH_TOKEN` secret
- Matches the pattern used in edilio and other Navigaite repos

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, Copilot review on next PR should trigger Claude Code to auto-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)