### PR TITLE
fix(release): base next version on latest git tag

### DIFF
--- a/.github/workflows/cron-weekly-release.yaml
+++ b/.github/workflows/cron-weekly-release.yaml
@@ -162,9 +162,10 @@ jobs:
       - name: 🔢 Determine version
         id: bump
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          set -euo pipefail
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           RANGE="HEAD"
-          if [[ -n "$LAST_TAG" ]]; then
+          if [[ "$LAST_TAG" != "v0.0.0" ]]; then
             RANGE="${LAST_TAG}..HEAD"
           fi
 
@@ -179,7 +180,20 @@ jobs:
             BUMP_TYPE="minor"
           fi
 
-          NEW_VERSION=$(npm version "$BUMP_TYPE" --no-git-tag-version)
+          # Compute next version from LAST_TAG (source of truth), not package.json
+          # which can drift out of sync if a previous bump PR wasn't merged.
+          CURRENT_VERSION="${LAST_TAG#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+          case "$BUMP_TYPE" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+          NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+
+          # Sync package.json for the subsequent bump PR
+          npm version "${NEW_VERSION#v}" --no-git-tag-version --allow-same-version >/dev/null
+
           echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
       - name: 📦 Create tag and GitHub Release

--- a/.github/workflows/cron-weekly-release.yaml
+++ b/.github/workflows/cron-weekly-release.yaml
@@ -163,7 +163,18 @@ jobs:
         id: bump
         run: |
           set -euo pipefail
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+
+          # Restrict to semver release tags (vMAJOR.MINOR.PATCH) to ignore any
+          # non-release tags (maintenance, CI, etc.).
+          SEMVER_PATTERN='v[0-9]*.[0-9]*.[0-9]*'
+          LAST_TAG=$(git describe --tags --abbrev=0 --match "$SEMVER_PATTERN" 2>/dev/null || echo "v0.0.0")
+
+          # Validate the resolved tag matches strict semver before arithmetic.
+          if ! [[ "$LAST_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Latest release tag '$LAST_TAG' does not match expected semver format (vMAJOR.MINOR.PATCH)"
+            exit 1
+          fi
+
           RANGE="HEAD"
           if [[ "$LAST_TAG" != "v0.0.0" ]]; then
             RANGE="${LAST_TAG}..HEAD"


### PR DESCRIPTION
## Summary
The weekly release workflow was failing with `Release.tag_name already exists` on every recent run.

## Root cause
The version bump step read from `package.json` (stuck at `5.1.0`) and bumped to `5.2.0` — but `v5.2.0` was already tagged. The `package.json` version drifted out of sync with the actual git tags because the "Close stale release PRs" step closes bump PRs before they merge, and if the release creation fails (as it did), the bump PR is also never reopened.

## Fix
Compute the next version from `git describe --tags --abbrev=0` (source of truth for releases) instead of `package.json`. Then sync `package.json` for the subsequent bump PR.

## Test plan
- [ ] CI passes
- [ ] Manual workflow_dispatch run produces `v5.3.0` (or `v5.2.1` if no feat: commits)
- [ ] Bump PR updates package.json from 5.1.0 to the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)