### PR TITLE
refactor(release): bump package.json in-pipeline instead of via PR

### DIFF
--- a/.github/workflows/cron-weekly-release.yaml
+++ b/.github/workflows/cron-weekly-release.yaml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
       changelog: ${{ steps.changelog.outputs.changelog }}
+      head_sha: ${{ steps.check.outputs.head_sha }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
@@ -33,6 +34,12 @@ jobs:
       - name: 🔍 Check for changes since last release
         id: check
         run: |
+          # Pin the HEAD SHA used for changelog generation so the downstream
+          # release job tags exactly the commits summarized here (avoids a
+          # race where main advances between jobs).
+          HEAD_SHA=$(git rev-parse HEAD)
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [[ -z "$LAST_TAG" ]]; then
             echo "No previous tag found, treating as first release"
@@ -132,8 +139,15 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v6
         with:
+          # Pin to the same SHA that check-updates generated the changelog from
+          # so the tag we create reflects exactly those commits.
+          ref: ${{ needs.check-updates.outputs.head_sha }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+      - name: 🟢 Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
       - name: 👤 Configure git
         run: |
           git config user.name "github-actions[bot]"
@@ -184,17 +198,28 @@ jobs:
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
       - name: 📝 Bump package.json and push to main
         id: commit
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           NEW_VERSION="${{ steps.bump.outputs.version }}"
           npm version "${NEW_VERSION#v}" --no-git-tag-version --allow-same-version >/dev/null
+
+          # Idempotent: if package.json is already at NEW_VERSION (e.g., a previous
+          # run of this job already pushed the bump before failing elsewhere), skip
+          # the commit/push and reuse the existing HEAD.
+          if git diff --quiet package.json package-lock.json; then
+            echo "No version changes to commit (already at ${NEW_VERSION})"
+            echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           git add package.json package-lock.json
-          # [skip ci] avoids running the Navigaite Pipeline on this bump commit
-          # (the release-trigger push is the only event we care about here).
+          # [skip ci] avoids running the Navigaite Pipeline on this bump commit.
           git commit -m "chore(release): ${NEW_VERSION} [skip ci]"
-          git push origin main
+          # We checked out a detached HEAD at needs.check-updates.outputs.head_sha,
+          # so push explicitly to the main ref. Fails fast (non-fast-forward) if
+          # someone pushed to main between check-updates and now — which is the
+          # safe behavior; we'd rather fail than tag a diverged history.
+          git push origin HEAD:main
           echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: 📦 Create tag and GitHub Release
         env:

--- a/.github/workflows/cron-weekly-release.yaml
+++ b/.github/workflows/cron-weekly-release.yaml
@@ -138,27 +138,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: 🧹 Close stale release PRs
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          mapfile -t PR_NUMBERS < <(
-            gh pr list \
-              --state open \
-              --base main \
-              --json number,headRefName \
-              --jq '.[] | select(.headRefName | startswith("release-please--") or startswith("release/")) | .number'
-          )
-
-          if [[ ${#PR_NUMBERS[@]} -eq 0 ]]; then
-            echo "No stale release PRs found."
-            exit 0
-          fi
-
-          for pr in "${PR_NUMBERS[@]}"; do
-            echo "Closing stale release PR #$pr"
-            gh pr close "$pr" --comment "Closed by weekly automated release workflow."
-          done
       - name: 🔢 Determine version
         id: bump
         run: |
@@ -191,8 +170,7 @@ jobs:
             BUMP_TYPE="minor"
           fi
 
-          # Compute next version from LAST_TAG (source of truth), not package.json
-          # which can drift out of sync if a previous bump PR wasn't merged.
+          # Compute next version from LAST_TAG (the source of truth for releases).
           CURRENT_VERSION="${LAST_TAG#v}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
           case "$BUMP_TYPE" in
@@ -202,17 +180,29 @@ jobs:
           esac
           NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
 
-          # Sync package.json for the subsequent bump PR
-          npm version "${NEW_VERSION#v}" --no-git-tag-version --allow-same-version >/dev/null
-
           echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+      - name: 📝 Bump package.json and push to main
+        id: commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          NEW_VERSION="${{ steps.bump.outputs.version }}"
+          npm version "${NEW_VERSION#v}" --no-git-tag-version --allow-same-version >/dev/null
+          git add package.json package-lock.json
+          # [skip ci] avoids running the Navigaite Pipeline on this bump commit
+          # (the release-trigger push is the only event we care about here).
+          git commit -m "chore(release): ${NEW_VERSION} [skip ci]"
+          git push origin main
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: 📦 Create tag and GitHub Release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Target the bump commit explicitly so the tag includes the synced package.json
           gh release create "${{ steps.bump.outputs.version }}" \
-            --target main \
+            --target "${{ steps.commit.outputs.commit_sha }}" \
             --title "${{ steps.bump.outputs.version }}" \
             --notes "$(cat <<RELEASE_EOF
           ## 📦 Weekly Plugin Release — ${{ steps.bump.outputs.version }}
@@ -237,21 +227,6 @@ jobs:
           _Automated weekly release by Navigaite CI/CD_
           RELEASE_EOF
           )"
-      - name: 🔄 Create version bump PR
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          BRANCH="release/${{ steps.bump.outputs.version }}"
-          git checkout -b "$BRANCH"
-          git add package.json package-lock.json
-          git commit -m "chore(release): ${{ steps.bump.outputs.version }}"
-          git push origin "$BRANCH"
-          gh pr create \
-            --title "chore(release): ${{ steps.bump.outputs.version }}" \
-            --body "Automated version bump to ${{ steps.bump.outputs.version }}." \
-            --base main \
-            --head "$BRANCH" \
-            --label "automerge"
       - name: 📊 Release Summary
         run: |
           echo "### 📦 Release Created" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Replace the post-release "create bump PR" step with an in-pipeline commit that updates `package.json` and pushes directly to `main` before the release is tagged. The tag then includes the synced `package.json`.

## Why
The previous two-step flow (tag first, bump PR second) caused `package.json` to drift permanently because the next run's "Close stale release PRs" step would close the unmerged bump PR before it could be merged. This was the original cause of the `v5.2.0` release failure.

## Changes
- Add `📝 Bump package.json and push to main` step: runs `npm version`, commits, and pushes to main with `[skip ci]` before tag creation
- Change `📦 Create tag and GitHub Release` to target the bump commit SHA (not the `main` ref) to avoid races
- Remove `🧹 Close stale release PRs` step — no longer needed (no `release/*` branches created)
- Remove now-unused `npm version` inside the determine-version step (that was only for the bump PR)

## How it works
The `navigaite-workflow-app` bot has bypass on the protected-branches ruleset, so it can push directly to `main`. The `[skip ci]` marker keeps the Navigaite Pipeline from re-running on the bump commit.

## Test plan
- [ ] CI passes
- [ ] Manual `workflow_dispatch` run bumps `package.json` and tags a new release from that commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)