### PR TITLE
ci: bump universal-pipeline caller to @v3 (PRI-676)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   pipeline:
-    uses: navigaite/.github/.github/workflows/universal-pipeline.yaml@v2
+    uses: navigaite/.github/.github/workflows/universal-pipeline.yaml@v3
     with:
       config-file: .github/pipeline.yaml
       skip-security: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Canary for PRI-676 — migrate universal-pipeline callers from `@v2` to `@v3`.

## What

`.github/workflows/ci.yaml`: `universal-pipeline.yaml@v2` → `@v3` (currently v3.2.1).

## Why

The PRI-630 job fold and every other v3 fix are inert for callers pinned to `@v2`. This repo is the canary (lowest blast radius) before `platzl-finder` / `maimaldrei-*`.

## v2 → v3 compatibility check

- **Caller interface unchanged.** `diff` of the `workflow_call` block (inputs + secrets) between `v2` and `v3.2.1` is empty. No caller change beyond the tag.
- **Config schema unchanged.** `version: '2.0'` in `.github/pipeline.yaml` is what `navigaite/edilio` already runs against `@v3`. No reconciliation needed.
- **The breaking change is job names.** v2 jobs `security` / `lint` / `test` / `build` / `pipeline-summary` fold into v3 `static-checks` / `verify`; `📊 Pipeline Summary` is now a step inside `setup`, not its own job. This repo never references inner job names — `check-gate` gates on `needs.pipeline.result` only — and the required checks are `Check Gate` / `Branch Guard`, both defined in this file. So nothing breaks.

## Expected effect

Job count per run drops by one (no standalone `📊 Pipeline Summary` job).

Refs PRI-676, PRI-630, PRI-626.